### PR TITLE
fix: pin dompurify patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5779,13 +5779,10 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/package.json
+++ b/package.json
@@ -117,12 +117,12 @@
       "minimatch@>=5.0.0 <5.1.7": ">=5.1.7",
       "minimatch@10.2.0": "10.2.3",
       "js-yaml@>=4.0.0 <4.1.1": ">=4.1.1",
-      "dompurify": ">=3.3.2",
+      "dompurify": "3.4.0",
       "rollup": ">=4.59.0"
     }
   },
   "overrides": {
-    "dompurify": ">=3.3.2",
+    "dompurify": "3.4.0",
     "rollup": ">=4.59.0"
   }
 }


### PR DESCRIPTION
## Summary
- pin npm and pnpm dompurify overrides to 3.4.0
- refresh package-lock so monaco-editor, posthog-js, and redoc resolve the patched DOMPurify release

## Verification
- npm ci
- npm --prefix server ci
- npm run lint
- npm run lint:server
- npm run typecheck
- npm run typecheck:server
- npm run build
- npm run test:unit
- npm run docs:api