### PR TITLE
fix: force patched postcss resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10640,35 +10640,6 @@
         }
       }
     },
-    "node_modules/styled-components/node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",

--- a/package.json
+++ b/package.json
@@ -118,11 +118,13 @@
       "minimatch@10.2.0": "10.2.3",
       "js-yaml@>=4.0.0 <4.1.1": ">=4.1.1",
       "dompurify": "3.4.0",
+      "postcss": "8.5.12",
       "rollup": ">=4.59.0"
     }
   },
   "overrides": {
     "dompurify": "3.4.0",
+    "postcss": "$postcss",
     "rollup": ">=4.59.0"
   }
 }


### PR DESCRIPTION
Fixes Dependabot alert #91 by forcing transitive PostCSS resolution to the already-patched root PostCSS version.\n\nVerification:\n- npm ls postcss\n- npm audit --json (PostCSS advisory no longer present; remaining moderate audit items are unrelated brace-expansion/yaml)\n- npm run docs:api\n- npm run build