### PR TITLE
chore: resolve brace-expansion audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5116,9 +5116,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- update root lockfile brace-expansion transitive dependency from 5.0.5 to 5.0.6
- clear the remaining root npm audit advisory after Dependabot PR merges

## Verification
- npm ci --ignore-scripts
- npm audit --json
- npm --prefix server audit --json
- npm run typecheck
- npm run build
- npm run docs:api
- npm run test:unit