### PR TITLE
test: harden team member e2e reload wait

### DIFF
--- a/e2e/team-management.serial.spec.ts
+++ b/e2e/team-management.serial.spec.ts
@@ -202,8 +202,12 @@ test.describe('Team Management Flows', () => {
         for (let i = 0; i < optionCount; i++) {
           await teamSelector.click();
           await options.nth(i).click();
-          await page.waitForTimeout(1000);
-          if (await memberRow.isVisible().catch(() => false)) break;
+          try {
+            await expect(memberRow).toBeVisible({ timeout: 5000 });
+            break;
+          } catch {
+            // Keep searching; member rows reload asynchronously after team changes.
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- replace a fixed 1s wait in the team-member removal E2E flow with a condition-based wait for the selected team member row
- keep searching team options when the member list has not reloaded yet

## Why
A prior CI run hit a stale failure in `Team Management Flows › admin can remove a team member`. The team admin page reloads member rows asynchronously after changing the selected team, so a fixed timeout can check too early.

## Verification
- `git diff --check`
- `npx playwright test e2e/team-management.serial.spec.ts --project=chromium --list`
- `npm ci --ignore-scripts`
- `npm run typecheck`
- commit hook: `npm run lint` and `npm run check:large-files`

Full local E2E was not run because Docker is not running locally; PR CI should cover it.