### PR TITLE
fix(server): bump protobufjs override to 8.7.1

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5765,9 +5765,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.0.tgz",
-      "integrity": "sha512-PIOO89BMGMXGz2333TVv/OqPNVWm7w30ll/4FtLbtLBaonzJMYwTbAZSSlobjIy9MoUgIAxSVUpK7aP7EpTtkg==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+      "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"

--- a/server/package.json
+++ b/server/package.json
@@ -54,6 +54,6 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "protobufjs": "8.6.0"
+    "protobufjs": "8.7.1"
   }
 }


### PR DESCRIPTION
Bumps the server protobufjs override from 8.6.0 to 8.7.1 and refreshes the lockfile. This clears the two remaining moderate protobufjs advisories. Local validation passed: fresh npm install, zero audit findings, frontend and server builds/typechecks, lint with existing warnings only, 57 frontend tests, and 117 server tests.